### PR TITLE
Add waypoint creation/update/deletion

### DIFF
--- a/ros/src/meta_planner/include/meta_planner/meta_planner.h
+++ b/ros/src/meta_planner/include/meta_planner/meta_planner.h
@@ -128,7 +128,8 @@ private:
   size_t num_value_functions_;
 
   // Sequence of waypoints to go to. Plan each trajectory to the next one in line.
-  std::list<Vector3d> waypoints_;
+  std::vector<Vector3d> waypoints_;
+  size_t waypoint_index_ = 0;
 
   // Current position, with flag for whether been updated since initialization.
   Vector3d position_;

--- a/ros/src/meta_planner/include/meta_planner/meta_planner.h
+++ b/ros/src/meta_planner/include/meta_planner/meta_planner.h
@@ -57,6 +57,7 @@
 #include <meta_planner_msgs/Trajectory.h>
 #include <meta_planner_msgs/TrajectoryRequest.h>
 #include <meta_planner_msgs/SensorMeasurement.h>
+#include <meta_planner_msgs/Waypoint.h>
 #include <crazyflie_msgs/PositionVelocityStateStamped.h>
 
 #include <value_function_srvs/TrackingBoundBox.h>
@@ -107,7 +108,7 @@ private:
     const meta_planner_msgs::TrajectoryRequest::ConstPtr& msg);
 
   // Callback to handle new waypoints.
-  void WaypointCallback(const geometry_msgs::Vector3::ConstPtr& msg);
+  void WaypointCallback(const meta_planner_msgs::Waypoint::ConstPtr& msg);
 
   // Plan a trajectory from the given start to stop points, beginning at the
   // specified start time. Auto-publishes the result and returns whether

--- a/ros/src/meta_planner/src/meta_planner.cpp
+++ b/ros/src/meta_planner/src/meta_planner.cpp
@@ -250,7 +250,8 @@ void MetaPlanner::WaypointCallback(const meta_planner_msgs::Waypoint::ConstPtr& 
       return;
     }
     waypoints_.erase(msg->index);
-    if (msg->index < waypoint_index_ || msg->index == waypoints_.size() - 1) {
+    if (waypoint_index_ > 0 && (msg->index < waypoint_index_
+                                || waypoint_index_ == waypoints_.size())) {
       --waypoint_index_;
     }
   } else {

--- a/ros/src/meta_planner/src/meta_planner.cpp
+++ b/ros/src/meta_planner/src/meta_planner.cpp
@@ -247,6 +247,7 @@ void MetaPlanner::WaypointCallback(const meta_planner_msgs::Waypoint::ConstPtr& 
     if (msg->index >= waypoints_.size()) {
       ROS_ERROR("%s: Oops. Tried to remove non-existent waypoint.",
                 name_.c_str());
+      return;
     }
     waypoints_.erase(msg->index);
     if (msg->index < waypoint_index_ || msg->index == waypoints_.size() - 1) {

--- a/ros/src/meta_planner/src/meta_planner.cpp
+++ b/ros/src/meta_planner/src/meta_planner.cpp
@@ -249,8 +249,8 @@ void MetaPlanner::WaypointCallback(const meta_planner_msgs::Waypoint::ConstPtr& 
                 name_.c_str());
       return;
     }
-    waypoints_.erase(msg->index);
-    ROS_INFO("%s: Removed waypoint at index %d.", name_.c_str(), msg->index);
+    waypoints_.erase(waypoints_.begin() + msg->index);
+    ROS_INFO("%s: Removed waypoint at index %lu.", name_.c_str(), msg->index);
     if (waypoint_index_ > 0 && (msg->index < waypoint_index_
                                 || waypoint_index_ == waypoints_.size())) {
       --waypoint_index_;
@@ -262,17 +262,17 @@ void MetaPlanner::WaypointCallback(const meta_planner_msgs::Waypoint::ConstPtr& 
       return;
     }
     if (msg->index == waypoints_.size()) {
-      waypoints_.emplace_back(msg->position->x, msg->position->y,
-                              msg->poisition->z);
-      ROS_INFO("%s: Appended waypoint at index %d as (%lf, %lf, %lf).",
-               name_.c_str(), msg->index, msg->position->x, msg->position->y,
-               msg->position->z);
+      waypoints_.emplace_back(msg->position.x, msg->position.y,
+                              msg->position.z);
+      ROS_INFO("%s: Appended waypoint at index %lu as (%lf, %lf, %lf).",
+               name_.c_str(), msg->index, msg->position.x, msg->position.y,
+               msg->position.z);
     } else {
-      waypoints_[msg->index] = {msg->position->x, msg->position->y,
-                                msg->poisition->z};
-      ROS_INFO("%s: Updated waypoint at index %d to be (%lf, %lf, %lf).",
-               name_.c_str(), msg->index, msg->position->x, msg->position->y,
-               msg->position->z);
+      waypoints_[msg->index] = {msg->position.x, msg->position.y,
+                                msg->position.z};
+      ROS_INFO("%s: Updated waypoint at index %lu to be (%lf, %lf, %lf).",
+               name_.c_str(), msg->index, msg->position.x, msg->position.y,
+               msg->position.z);
     }
   }
   reached_goal_ = false;

--- a/ros/src/meta_planner/src/meta_planner.cpp
+++ b/ros/src/meta_planner/src/meta_planner.cpp
@@ -259,7 +259,9 @@ void MetaPlanner::WaypointCallback(const meta_planner_msgs::Waypoint::ConstPtr& 
     if (msg->index > waypoints_.size()) {
       ROS_ERROR("%s: Oops. Tried to update non-existent waypoint.",
                 name_.c_str());
-    } else if (msg->index == waypoints_.size()) {
+      return;
+    }
+    if (msg->index == waypoints_.size()) {
       waypoints_.emplace_back(msg->position->x, msg->position->y,
                               msg->poisition->z);
       ROS_INFO("%s: Appended waypoint at index %d as (%lf, %lf, %lf).",

--- a/ros/src/meta_planner/src/meta_planner.cpp
+++ b/ros/src/meta_planner/src/meta_planner.cpp
@@ -250,6 +250,7 @@ void MetaPlanner::WaypointCallback(const meta_planner_msgs::Waypoint::ConstPtr& 
       return;
     }
     waypoints_.erase(msg->index);
+    ROS_INFO("%s: Removed waypoint at index %d.", name_.c_str(), msg->index);
     if (waypoint_index_ > 0 && (msg->index < waypoint_index_
                                 || waypoint_index_ == waypoints_.size())) {
       --waypoint_index_;
@@ -261,9 +262,15 @@ void MetaPlanner::WaypointCallback(const meta_planner_msgs::Waypoint::ConstPtr& 
     } else if (msg->index == waypoints_.size()) {
       waypoints_.emplace_back(msg->position->x, msg->position->y,
                               msg->poisition->z);
+      ROS_INFO("%s: Appended waypoint at index %d as (%lf, %lf, %lf).",
+               name_.c_str(), msg->index, msg->position->x, msg->position->y,
+               msg->position->z);
     } else {
       waypoints_[msg->index] = {msg->position->x, msg->position->y,
                                 msg->poisition->z};
+      ROS_INFO("%s: Updated waypoint at index %d to be (%lf, %lf, %lf).",
+               name_.c_str(), msg->index, msg->position->x, msg->position->y,
+               msg->position->z);
     }
   }
   reached_goal_ = false;

--- a/ros/src/meta_planner_msgs/msg/Waypoint.msg
+++ b/ros/src/meta_planner_msgs/msg/Waypoint.msg
@@ -1,3 +1,7 @@
+# Index of waypoint in route.
+# Use an index of #waypoints to add a new waypoint at the end.
 uint64 index
+# New waypoint position for addition or update.
 geometry_msgs/Vector3 position
+# If true, the waypoint at index will be removed.
 bool remove

--- a/ros/src/meta_planner_msgs/msg/Waypoint.msg
+++ b/ros/src/meta_planner_msgs/msg/Waypoint.msg
@@ -1,0 +1,3 @@
+uint64 index
+geometry_msgs/Vector3 position
+bool remove


### PR DESCRIPTION
I've made some changes so that waypoints can be updated or deleted. Now the meta planner keeps track of all waypoints it received, instead of a queue of upcoming waypoints.

The new ROS message:

```
uint64 index
geometry_msgs/Vector3 position
bool remove
```

- If `remove` is true, the waypoint at `index` will be removed, and the `position` field is ignored.
- If `index` is at `waypoints_.size()`, a new waypoint with `position` is added.
- If `index` is less than `waypoints_.size()`, the waypoint at `index` is updated to match `position`.
